### PR TITLE
fix: Enable Log tabs visibility in AppLogReader permission set

### DIFF
--- a/force-app/main/default/permissionsets/AppLogReader.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/AppLogReader.permissionset-meta.xml
@@ -80,8 +80,16 @@
         <tab>AppLog__c</tab>
         <visibility>Available</visibility>
     </tabSettings>
-    <tabSettings>
+   <tabSettings>
         <tab>Log_List</tab>
+        <visibility>Visible</visibility>
+    </tabSettings>
+    <tabSettings>
+        <tab>Log_Reader</tab>
+        <visibility>Visible</visibility>
+    </tabSettings>
+    <tabSettings>
+        <tab>Log_Tester</tab>
         <visibility>Visible</visibility>
     </tabSettings>
 </PermissionSet>

--- a/force-app/main/default/permissionsets/AppLogReader.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/AppLogReader.permissionset-meta.xml
@@ -80,4 +80,8 @@
         <tab>AppLog__c</tab>
         <visibility>Available</visibility>
     </tabSettings>
+    <tabSettings>
+        <tab>Log_List</tab>
+        <visibility>Visible</visibility>
+    </tabSettings>
 </PermissionSet>


### PR DESCRIPTION
This PR adds tab visibility settings to the AppLogReader permission set to ensure users can see the Log_List, Log_Reader, and Log_Tester tabs in the App Logs application.

Changes:
- Added tab visibility settings to AppLogReader permission set
- Set Log_List, Log_Reader, and Log_Tester tabs to Visible